### PR TITLE
Fix separator character in push

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -531,6 +531,11 @@ function islandora_datastream_crud_parse_dsfilename($filepath) {
     return FALSE;
   }
 
+  if ($filename_separator !== '_') {
+    list($pid, $dsid) = explode($filename_separator, $filename);
+    return array($pid, $dsid);
+  }
+
   // The default case is namesapce_number_DSID.
   if (substr_count($filename, '_') == 2) {
     list($namespace, $number, $dsid) = explode('_', $filename);


### PR DESCRIPTION
# Github issue

[(link)](https://github.com/SFULibrary/islandora_datastream_crud/issues/93)

# Other Relevant Links (Google Groups discussion, related pull requests, etc.)

Method is called:
https://github.com/SFULibrary/islandora_datastream_crud/blob/1509191b3f21bd2e866f78eaad145103cf2759f3/islandora_datastream_crud.drush.inc#L487
and
https://github.com/SFULibrary/islandora_datastream_crud/blob/1509191b3f21bd2e866f78eaad145103cf2759f3/islandora_datastream_crud.drush.inc#L499

# What does this Pull Request do?

This allows for `--filename_separator` to work as expected in push operations.

# What's new?

Calculate the verbatim PID and DSID first, if using the explicit separator.  Otherwise, fall back to the lossy underscore logic.

# How should this be tested?

`islandora_datastream_crud_push_datastreams --filename_separator=^`

# Additional Notes

Example error output:
```
Working Temporary Directory: /workbench/mrbst20/tmp.gokjI8YgPZ
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F001_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F002_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F003_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F003_I02^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F004_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F004_I02^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F004_I03^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F005_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F006_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F006_I02^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F007_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F007_I02^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F007_I03^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F008_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F009_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F009_I02^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F009_I03^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F009_I04^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F010_I01^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F010_I02^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F010_I03^RELS-EXT.rdf
/workbench/mrbst20/tmp.gokjI8YgPZ/rels-ext/pitt:PSS031_B001_F011_I01^RELS-EXT.rdf
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
The PID (pitt:PSS031:B001) is not valid.                                                                                 [error]
CRUD push returned an error
```

# Interested parties

